### PR TITLE
Migrate module manifests

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,33 +9,31 @@ At this time, only Vue 2 is supported, though support for Vue 3 will be added in
 # Using VuePort!
 
 To use VuePort!, you need to have a Vue component and to depend on the `vueport` library. You would also need to depend on `dlopen`, as it gets used to dynamically load your components.
-In your module.json, add the follow dependencies : 
+In your module.json, add the follow dependencies :
+
 ```json
-    "dependencies": [
-        {
-            "type": "module",
-            "name": "vueport"
-        },
-        {
-            "type": "module",
-            "name": "dlopen"
-        }
-    ],
+    "relationships": {
+        "requires": [
+            { "id": "vueport", "type": "module" },
+            { "id": "dlopen", "type": "module" }
+        ]
+    },
 ```
 
-In your module, simply create an element with the class `'vueport-render'` and the Vue component will be created automatically for you using the component name. This does imply that all components need to be globally registered. You can also add the `dependencies` attribute to your element to specify a space-separated list of dependencies to load via `dlopen` (the dependencies need to be registered beforehand).
+In your module, simply create an element with the class **`vueport-render`** and the Vue component will be created automatically for you using the component name. This does imply that all components need to be globally registered. You can also add the `dependencies` attribute to your element to specify a space-separated list of dependencies to load via `dlopen` (the dependencies need to be registered beforehand).
 
-You can create the element manually via code, or you can embed your Vue components in the middle of your existing handlebars templates : 
+You can create the element manually via code, or you can embed your Vue components in the middle of your existing handlebars templates :
+
 ```hbs
 <div>
-  This is in my handlebars template file for module {{ moduleName }}
-  <my-vue-port-component class="vueport-render" :my-property="myJSONStringifiedData">
-    Loading, please wait... 
-    <!--
-      the inside of the component will be displayed as a div until the component is loaded and rendered,
-      which is practical to show a 'loading...' message while your dependencies are being fetched
-    -->
-  </my-vue-port-component>
+    This is in my handlebars template file for module {{moduleName}}
+    <my-vue-port-component class="vueport-render" :my-property="myJSONStringifiedData">
+        Loading, please wait...
+        <!--
+        the inside of the component will be displayed as a div until the component is loaded and rendered,
+        which is practical to show a 'loading...' message while your dependencies are being fetched
+        -->
+    </my-vue-port-component>
 </div>
 ```
 
@@ -44,44 +42,45 @@ It is highly recommended to have your vue components loaded dynamically by using
 You can also use `VuePort.render` to render a specific component with a custom data object or a vuex store and have it mounted on the element of your choice.
 Note that you can render an object directly with `:attr=${JSON.stringify(object)}` if you need to pass a non-string value attribute to a component, as shown in the above hbs example
 
-
 # Using vue-cli
 
 You can use the vue-cli service to create your vue project, then edit the `package.json` file to add a new script which builds it as a umd library.
+
 ```json
-   "scripts": {
-    "serve": "vue-cli-service serve",
-    "build": "vue-cli-service build",
-    "lint": "vue-cli-service lint",
-    "umd": "vue-cli-service build --target lib --name MyVueComponent src/App.vue"
-  },
+    "scripts": {
+        "serve": "vue-cli-service serve",
+        "build": "vue-cli-service build",
+        "lint": "vue-cli-service lint",
+        "umd": "vue-cli-service build --target lib --name MyVueComponent src/App.vue"
+    },
 ```
 
 When running the `npm run umd` command, your component (`src/App.vue`) will be compiled into the UMD format and will be available under `dist/MyVueComponent.umd.js` and `dist/MyVueComponent.css`
 
+In your init hook, create a dynamic dependency to load your module's vue components by calling `Dlopen.register` :
 
-In your init hook, create a dynamic dependency to load your module's vue components by calling `Dlopen.register` : 
 ```js
 Hooks.on("init", () => {
-        Dlopen.register('my-module-name-vue', {
-            scripts: "/modules/my-module-name/dist/MyVueComponent.umd.js",
-            styles: "/modules/my-module-name/dist/MyVueComponent.css",
-            init: () => Vue.component(MyVueComponent.name, MyVueComponent),
-            dependencies: "vue"
-        });
+    Dlopen.register("my-module-name-vue", {
+        scripts: "/modules/my-module-name/dist/MyVueComponent.umd.js",
+        styles: "/modules/my-module-name/dist/MyVueComponent.css",
+        init: () => Vue.component(MyVueComponent.name, MyVueComponent),
+        dependencies: "vue"
+    });
 });
 ```
 
 You can then have your js and css files loaded automatically as dependencies before the component is displayed. This is practical to avoid loading everything when Foundry boots, but instead loading the Vue components only when the user opens the UI.
+
 ```html
 <my-vue-component class="vueport-render" dependencies="my-module-name-vue">
-    Loading, please wait... 
+    Loading, please wait...
 </my-vue-component>
 ```
 
 # Using Gulp (DEPRECATED)
 
-Alternatively, you can also use the provided gulp scripts to build only your vue component without the vue dependency packed into it, which results in smaller files. 
+Alternatively, you can also use the provided gulp scripts to build only your vue component without the vue dependency packed into it, which results in smaller files.
 
 Create your .vue files, copy the gulpfile example and rename it, copy the package.json file or install with this command (note gulp-vue-single-file-component is broken in latest version)
 `npm install --save gulp gulp-concat gulp-wrap gulp-declare gulp-minify gulp-vue-single-file-component@1.0.12 gulp-babel @babel/core @babel/plugin-transform-modules-commonjs`
@@ -89,13 +88,14 @@ Create your .vue files, copy the gulpfile example and rename it, copy the packag
 run `npm run build` to build your file which has all the components bundled (or run `npx gulp`).
 You can also run `npm run watch` to have it build and continually watch your files for any changes and rebuild them automatically (useful during development).
 
-When using the gulp method, the css is not compiled as a separate file, and there is no need for an init function to register the component globally. All `.vue` files in the `vue` folder and subfolders will automatically be registered : 
+When using the gulp method, the css is not compiled as a separate file, and there is no need for an init function to register the component globally. All `.vue` files in the `vue` folder and subfolders will automatically be registered :
+
 ```js
 Hooks.on("init", () => {
-        Dlopen.register('my-module-name-vue', {
-            scripts: "/modules/my-module-name/dist/vue-components.min.js",
-            dependencies: "vue"
-        });
+    Dlopen.register("my-module-name-vue", {
+        scripts: "/modules/my-module-name/dist/vue-components.min.js",
+        dependencies: "vue"
+    });
 });
 ```
 

--- a/module.json
+++ b/module.json
@@ -1,20 +1,34 @@
 {
     "name": "vueport",
+    "id": "vueport",
     "title": "VuePort: Let the Light in!",
     "description": "<p>Using Handlebars is like switching from Theatre of the Mind to using a ruler to help tracing your grid in your pen & paper game. Using Vue is like switching to Foundry VTT instead!</p><p>Open the VuePort, let the light in and bask in the glory!</p><p>This library module, contributed by The Forge, provides an easy way to integrate Vue.js within your Foundry applications. See README for details on how to use it.</p>",
     "version": "1.1",
-    "authors": [{
-        "name": "KaKaRoTo (The Forge)",
-        "url": "https://forge-vtt.com"
-    }],
+    "authors": [
+        {
+            "name": "KaKaRoTo (The Forge)",
+            "url": "https://forge-vtt.com"
+        }
+    ],
     "scripts": ["./vueport.js"],
     "styles": [],
     "packs": [],
-    "dependencies": [{
-        "name": "dlopen",
-        "type": "module",
-        "manifest": "https://raw.githubusercontent.com/ForgeVTT/fvtt-module-dlopen/master/module.json"
-    }],
+    "dependencies": [
+        {
+            "name": "dlopen",
+            "type": "module",
+            "manifest": "https://raw.githubusercontent.com/ForgeVTT/fvtt-module-dlopen/master/module.json"
+        }
+    ],
+    "relationships": {
+        "requires": [
+            {
+                "id": "dlopen",
+                "type": "module",
+                "manifest": "https://raw.githubusercontent.com/ForgeVTT/fvtt-module-dlopen/master/module.json"
+            }
+        ]
+    },
     "languages": [
         {
             "lang": "en",
@@ -25,6 +39,11 @@
     "url": "https://github.com/ForgeVTT/fvtt-module-vueport",
     "manifest": "https://raw.githubusercontent.com/ForgeVTT/fvtt-module-vueport/master/module.json",
     "download": "https://github.com/ForgeVTT/fvtt-module-vueport/archive/v1.1.zip",
-    "minimumCoreVersion": "0.6.0",
-    "compatibleCoreVersion": "1.0.0"
+    "minimumCoreVersion": 9,
+    "compatibleCoreVersion": 12,
+    "compatibility": {
+        "minimum": 9,
+        "verified": 12,
+        "maximum": 13
+    }
 }

--- a/vueport-hello-world/module.json
+++ b/vueport-hello-world/module.json
@@ -1,24 +1,34 @@
 {
-    "name": "vueport-hello-world",
+    "id": "vueport-hello-world",
     "title": "VuePort: Hello world module to demo VuePort",
     "description": "Not to be used for real, hello world module to showcase how to use VuePort",
     "version": "1.0",
-    "authors": [{
-        "name": "KaKaRoTo (The Forge)",
-        "url": "https://forge-vtt.com"
-    }],
+    "authors": [
+        {
+            "name": "KaKaRoTo (The Forge)",
+            "url": "https://forge-vtt.com"
+        }
+    ],
     "scripts": ["./hello-world.js"],
     "styles": [],
     "packs": [],
-    "dependencies": [{
-        "name": "dlopen",
-        "type": "module",
-        "manifest": "https://raw.githubusercontent.com/ForgeVTT/fvtt-module-dlopen/master/module.json"
-    },{
-        "name": "vueport",
-        "type": "module",
-        "manifest": "https://raw.githubusercontent.com/ForgeVTT/fvtt-module-vueport/master/module.json"
-    }],
-    "minimumCoreVersion": "0.0.0",
-    "compatibleCoreVersion": "1.0.0"
+    "relationships": {
+        "requires": [
+            {
+                "id": "dlopen",
+                "type": "module",
+                "manifest": "https://raw.githubusercontent.com/ForgeVTT/fvtt-module-dlopen/master/module.json"
+            },
+            {
+                "id": "vueport",
+                "type": "module",
+                "manifest": "https://raw.githubusercontent.com/ForgeVTT/fvtt-module-vueport/master/module.json"
+            }
+        ]
+    },
+    "compatibility": {
+        "minimum": 9,
+        "verified": 12,
+        "maximum": 13
+    }
 }

--- a/vueport-hello-world/module.json
+++ b/vueport-hello-world/module.json
@@ -27,7 +27,7 @@
         ]
     },
     "compatibility": {
-        "minimum": 9,
+        "minimum": 10,
         "verified": 12,
         "maximum": 13
     }


### PR DESCRIPTION
- Add `id`, `relationships` and `compatibility` fields to _module.json_. Keep [old v9 attributes](https://foundryvtt.com/article/manifest-migration-guide).
- Replace `name` with `id`, `dependencies` with `relationships.requires` and `minimumCoreVersion`/`compatibleCoreVersion` with `compatibility on _vueport-hello-world/module.json_.